### PR TITLE
添加blog_url填入错误提示，添加取消全局ssh认证逻辑

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # pycnblog
+
 博客园上传markdown文件 https://www.cnblogs.com/df888/p/11826480.html
 
 # 功能
@@ -20,7 +21,7 @@ python3
 在config.yaml中，填写博客配置信息。
 
 ```python
-blog_url: https://rpc.cnblogs.com/metaweblog/testblog
+blog_url: https: // rpc.cnblogs.com / metaweblog / testblog
 blog_id: "testblog"
 username: "zhangsan"
 password: "123456"
@@ -33,8 +34,7 @@ https://rpc.cnblogs.com/metaweblog/testblog
 
 ## blog_id
 
-blog_id就是访问地址的尾巴，
-testblog。
+blog_id就是访问地址的尾巴， testblog。
 
 ## username
 
@@ -51,5 +51,9 @@ windows cmd:<br/>
 把文件往里一拖，回车就完事了。
 
 mac:<br/>
-配置PATH，`cd ~/`， `vim .bash_profile`，输入`i`编辑，添加`export PATH=/tool_local_path/:$PATH`，按下 “ESC” 按钮，输入`:wq!`，回车保存。立即生效，`source ~/.bash_profile`。`cd tool_local_path`，修改可执行文件权限，`chmod 777 cnblogmd`。修改`cnblogmd`文件，`/tool_local_path/upload.py`。 <br/>
+配置PATH，`cd ~/`， `vim .bash_profile`，输入`i`编辑，添加`export PATH=/tool_local_path/:$PATH`，按下 “ESC” 按钮，输入`:wq!`
+，回车保存。立即生效，`source ~/.bash_profile`。`cd tool_local_path`，修改可执行文件权限，`chmod 777 cnblogmd`。修改`cnblogmd`
+文件，`/tool_local_path/upload.py`。 <br/>
 以后直接打开终端，输入cnblogmd，就可以了。
+---
+#####可以直接使用python3 upload.py xxx.md命令

--- a/README.md
+++ b/README.md
@@ -57,3 +57,4 @@ mac:<br/>
 以后直接打开终端，输入cnblogmd，就可以了。
 ---
 #####可以直接使用python3 upload.py xxx.md命令
+#### 这个文章写得比较详细 https://www.cnblogs.com/gered/p/14736136.html

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 blog_url: xxx
-blog_id: "xxx"
-username: "xxx"
-password: "xxx"
+blog_id: xxx
+username: xxx
+password: xxx
 
 # 是否生成图片替换后本地文件,默认False关闭
 gen_network_file: False

--- a/img_transfer.py
+++ b/img_transfer.py
@@ -54,4 +54,3 @@ def replace_md_img(path, img_mapping):
                 fw.write(md)
                 print(f'图片链接替换完成，生成新markdown:{path_net}')
         return md
-

--- a/server_proxy.py
+++ b/server_proxy.py
@@ -3,4 +3,9 @@ import xmlrpc.client
 from config_loader import conf
 
 blog_url = conf["blog_url"].strip()
-server = xmlrpc.client.ServerProxy(blog_url)
+try:
+    server = xmlrpc.client.ServerProxy(blog_url)
+except Exception as e:
+    e = str(e)
+    if 'unsupported XML-RPC protocol' in e:
+        print('请查看config.yaml文件中的blog_url,应该是这个URL地址没设置对')

--- a/upload.py
+++ b/upload.py
@@ -1,5 +1,6 @@
 import asyncio
 import html
+import ssl
 import sys
 import xmlrpc.client
 
@@ -27,56 +28,64 @@ def get_image_url(t):
     image_count += 1
 
 
-with open(md_path, encoding='utf-8') as f:
-    md = f.read()
-    print(f'markdown读取成功:{md_path}')
-    local_images = find_md_img(md)
+def cancel_ssh_authentication():  # 取消全局ssl认证
+    ssl._create_default_https_context = ssl._create_unverified_context
 
-    if local_images:  # 有本地图片，异步上传
-        tasks = []
-        for li in local_images:
-            image_full_path = os.path.join(dir_name, li)
-            task = asyncio.ensure_future(upload_img(image_full_path))
-            task.add_done_callback(get_image_url)
-            tasks.append(task)
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(asyncio.wait(tasks))
-        loop.close()
 
-        image_mapping = dict(zip(local_images, net_images))
+if __name__ == '__main__':
+    cancel_ssh_authentication()
+    with open(md_path, encoding='utf-8') as f:
+        md = f.read()
+        print(f'markdown读取成功:{md_path}')
+        local_images = find_md_img(md)
 
-        md = replace_md_img(md_path, image_mapping)
-    else:
-        print('无需上传图片')
+        if local_images:  # 有本地图片，异步上传
+            tasks = []
+            for li in local_images:
+                image_full_path = os.path.join(dir_name, li)
+                task = asyncio.ensure_future(upload_img(image_full_path))
+                task.add_done_callback(get_image_url)
+                tasks.append(task)
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(asyncio.wait(tasks))
+            loop.close()
 
-    post = dict(description=md, title=title, categories=['[Markdown]'])
-    recent_posts = server.metaWeblog.getRecentPosts(conf["blog_id"], conf["username"], conf["password"], 999999)
-    # 获取所有标题，需要处理HTML转义字符
-    recent_posts_titles = [html.unescape(recent_post['title']) for recent_post in recent_posts]
-    if title not in recent_posts_titles:
-        server.metaWeblog.newPost(conf["blog_id"], conf["username"], conf["password"], post, conf["publish"])
-        print(f"markdown上传成功, 博客标题为'{title}', 状态为'未发布', 请到博客园后台查看")
-    elif input('博客已存在, 是否更新?(y/n)') == 'y':
-        for recent_post in recent_posts:
-            if title == html.unescape(recent_post['title']):
-                update_post = recent_post
-                update_post['description'] = md
-                # 博客更新时保留摘要、标签
-                posted_article = server.metaWeblog.getPost(update_post['postid'], conf["username"], conf["password"])
-                try:
-                    update_post["mt_keywords"] = posted_article["mt_keywords"]
-                    update_post["mt_excerpt"] = posted_article["mt_excerpt"]
-                except KeyError:
-                    pass
-                try:
-                    server.metaWeblog.editPost(update_post['postid'], conf["username"], conf["password"], update_post,
-                                               False)
-                except xmlrpc.client.Fault as fault:
-                    if 'published post can not be saved as draft' in str(fault):
+            image_mapping = dict(zip(local_images, net_images))
+
+            md = replace_md_img(md_path, image_mapping)
+        else:
+            print('无需上传图片')
+
+        post = dict(description=md, title=title, categories=['[Markdown]'])
+        recent_posts = server.metaWeblog.getRecentPosts(conf["blog_id"], conf["username"], conf["password"], 999999)
+        # 获取所有标题，需要处理HTML转义字符
+        recent_posts_titles = [html.unescape(recent_post['title']) for recent_post in recent_posts]
+        if title not in recent_posts_titles:
+            server.metaWeblog.newPost(conf["blog_id"], conf["username"], conf["password"], post, conf["publish"])
+            print(f"markdown上传成功, 博客标题为'{title}', 状态为'未发布', 请到博客园后台查看")
+        elif input('博客已存在, 是否更新?(y/n)') == 'y':
+            for recent_post in recent_posts:
+                if title == html.unescape(recent_post['title']):
+                    update_post = recent_post
+                    update_post['description'] = md
+                    # 博客更新时保留摘要、标签
+                    posted_article = server.metaWeblog.getPost(update_post['postid'], conf["username"],
+                                                               conf["password"])
+                    try:
+                        update_post["mt_keywords"] = posted_article["mt_keywords"]
+                        update_post["mt_excerpt"] = posted_article["mt_excerpt"]
+                    except KeyError:
+                        pass
+                    try:
                         server.metaWeblog.editPost(update_post['postid'], conf["username"], conf["password"],
-                                                   update_post, True)
-                    else:
-                        raise fault
-                print(f"博客'{title}'更新成功")
-    else:
-        print('上传已取消')
+                                                   update_post,
+                                                   False)
+                    except xmlrpc.client.Fault as fault:
+                        if 'published post can not be saved as draft' in str(fault):
+                            server.metaWeblog.editPost(update_post['postid'], conf["username"], conf["password"],
+                                                       update_post, True)
+                        else:
+                            raise fault
+                    print(f"博客'{title}'更新成功")
+        else:
+            print('上传已取消')


### PR DESCRIPTION
1、python3.6运行时，会出现ssh未认证，因此我加入了ssl取消全局认证的逻辑。
2、当config.yaml中的blog_url配置错误，会出现OSError("unsupported XML-RPC protocol")，因此，我加入了try和一个提示信息“ 请查看config.yaml文件中的blog_url,应该是这个URL地址没设置对”
3、其他代码没改动，我只是格式化了一下代码
