### PR TITLE
完善找图规则及路径打印方式

### DIFF
--- a/img_transfer.py
+++ b/img_transfer.py
@@ -8,10 +8,11 @@ from server_proxy import server
 
 def find_md_img(md):
     """查找markdown中的图片，排除网络图片(不用上传)"""
-    images = re.findall("!\\[.*?\\]\\((.*)\\)", md)
+    images = re.findall("\\!\\[.*?\\]\\((.*?)\\)", md)
     images += re.findall('<img src="(.*?)"', md)
     images = [i for i in images if not re.match("((http(s?))|(ftp))://.*", i)]
-    print(f'共找到{len(images)}张本地图片{images}')
+    print(f'共找到{len(images)}张本地图片')
+    print(*images, sep='\n')
     return images
 
 


### PR DESCRIPTION
-  当两张图片在一起时，如![]()![]()，以上规则会将其识别为一张并在上传时由于无法找到路径而报错  
-  在`!` 前加转义会加快查找速度  
-  将每张图片路径换行打印