### PR TITLE
添加分类

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,3 +13,9 @@ publish: False
 # img_format: "<center><img src="{}" style="width:100%;" /></center>" 设置居中和宽度
 # img_format: typora 还原typora图片样式，居中，设置zoom，上传后无需再手动调整图片大小
 img_format: ""
+
+#要添加到的分类 多个分类用英文逗号分开 不用分类则不填即可 例如
+#categories: c++
+#categories: c++,learn
+#categories:
+categories:

--- a/config.yaml
+++ b/config.yaml
@@ -1,13 +1,13 @@
-blog_url: xxx
-blog_id: xxx
-username: xxx
-password: xxx
+blog_url: https://rpc.cnblogs.com/metaweblog/rainbow-tan
+blog_id: rainbow-tan
+username: 南风丶轻语
+password: C6AC1FD6E98D5ADFB241A7A9498BD538601ED1C1D214E3959DC4231CF512CB8E
 
 # 是否生成图片替换后本地文件,默认False关闭
-gen_network_file: False
+gen_network_file: True
 
 # 上传后是否发布，默认未发布，设置True为发布
-publish: False
+publish: True
 
 # 图片自定义显示格式，默认不设置
 # img_format: "<center><img src="{}" style="width:100%;" /></center>" 设置居中和宽度

--- a/config_loader.py
+++ b/config_loader.py
@@ -14,3 +14,27 @@ config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config.y
 
 with open(config_path, "r", encoding="utf-8") as f:
     conf = yaml.load(f.read(), Loader=yaml.FullLoader)
+
+
+def _check_categories(categories):
+    new = []
+    if categories:
+        for one in categories.split(','):
+            if str(one).strip() != "":
+                new.append(one)
+    else:
+        new = []
+    return new
+
+
+def check_categories(categories):
+    try:
+        categories = _check_categories(categories)
+        print(f"要添加到的分类为:{categories}")
+        return categories
+    except:
+        print("类别错误, 设置类别为空")
+        return []
+
+
+conf["categories"] = check_categories(conf["categories"])

--- a/upload.py
+++ b/upload.py
@@ -56,13 +56,14 @@ if __name__ == '__main__':
         else:
             print('无需上传图片')
 
-        post = dict(description=md, title=title, categories=['[Markdown]'])
+        post = dict(description=md, title=title, categories=['[Markdown]']+conf["categories"])
         recent_posts = server.metaWeblog.getRecentPosts(conf["blog_id"], conf["username"], conf["password"], 99)
         # 获取所有标题，需要处理HTML转义字符
         recent_posts_titles = [html.unescape(recent_post['title']) for recent_post in recent_posts]
         if title not in recent_posts_titles:
             server.metaWeblog.newPost(conf["blog_id"], conf["username"], conf["password"], post, conf["publish"])
-            print(f"markdown上传成功, 博客标题为'{title}', 状态为'未发布', 请到博客园后台查看")
+            print(f"markdown上传成功, 博客标题为'{title}', 状态为'{'已发布' if conf['publish'] else '未发布'}', "
+                  f"分类为:{conf['categories']} 请到博客园后台查看")
         elif input('博客已存在, 是否更新?(y/n)') == 'y':
             for recent_post in recent_posts:
                 if title == html.unescape(recent_post['title']):

--- a/upload.py
+++ b/upload.py
@@ -64,7 +64,7 @@ if __name__ == '__main__':
             server.metaWeblog.newPost(conf["blog_id"], conf["username"], conf["password"], post, conf["publish"])
             print(f"markdown上传成功, 博客标题为'{title}', 状态为'{'已发布' if conf['publish'] else '未发布'}', "
                   f"分类为:{conf['categories']} 请到博客园后台查看")
-        elif input('博客已存在, 是否更新?(y/n)') == 'y':
+        else:
             for recent_post in recent_posts:
                 if title == html.unescape(recent_post['title']):
                     update_post = recent_post
@@ -80,7 +80,7 @@ if __name__ == '__main__':
                     try:
                         server.metaWeblog.editPost(update_post['postid'], conf["username"], conf["password"],
                                                    update_post,
-                                                   False)
+                                                   conf["publish"])
                     except xmlrpc.client.Fault as fault:
                         if 'published post can not be saved as draft' in str(fault):
                             server.metaWeblog.editPost(update_post['postid'], conf["username"], conf["password"],
@@ -88,5 +88,4 @@ if __name__ == '__main__':
                         else:
                             raise fault
                     print(f"博客'{title}'更新成功")
-        else:
-            print('上传已取消')
+


### PR DESCRIPTION
（1）配置文件多加了一个参数categories用作于博客分类
    （1.1）默认不填和以前一样的功能，填了以后，且分类存在，就会指定博客分类
    （1.2）如果未存在该分类，则会新建一个分类
    （1.3）多个分类用英文逗号分割
（2）使用场景：当一次性写了很多博客，都属于一个分类，则可以指定分类，就不用还得手动一个一个修改博客，或者通过修改源代码来达到目的